### PR TITLE
Updated apps.py to support Django >3.2

### DIFF
--- a/src/urlshortening/apps.py
+++ b/src/urlshortening/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class UrlshorteningConfig(AppConfig):
-    name = 'src.urlshortening'
+    name = 'urlshortening'


### PR DESCRIPTION
From Django 3.2 onwards, src.urlshortening will throw error.